### PR TITLE
release: publish v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,30 @@ translations, commit messages, releases, etc.
 Support Censor indirectly by [donating to Codeberg][Codeberg Donate]. Thanks to
 [Codeberg][] for providing the git hosting platform with continuous integration
 and all the nice features of [Forgejo][] and [Weblate][] needed for the
-development of Censor.
+development of Censor. Further, I want to express my gratitude to [GNOME][] and
+[Flathub][] for providing resources needed for building and distributing test
+and release packages.
 
 [Codeberg Donate]: https://donate.codeberg.org
 [Codeberg]: https://codeberg.org/about
 [Forgejo]: https://forgejo.org
 [Weblate]: https://weblate.org
+[GNOME]: https://www.gnome.org/
+[Flathub]: https://flathub.org/
+
+## Testing
+
+Censor uses the [GNOME][] infrastructure to
+[build test flatpak bundles][gitlab-ci] for [pull requests][build-start]. Unit
+tests are implemented using the [pytest][] library. Thanks to [py-pdf][]
+contributors for providing [sample files][] for testing Censor’s functionality!
+
+[gitlab-ci]: https://codeberg.org/censor/Censor/src/branch/main/.gitlab-ci.yml
+[build-start]: https://codeberg.org/censor/Censor/src/branch/main/.forgejo/workflows/build-start.yml
+[checks]: https://codeberg.org/censor/Censor/src/branch/main/.forgejo/workflows/checks.yml
+[pytest]: https://pytest.org/
+[py-pdf]: https://py-pdf.github.io/
+[sample files]: https://github.com/py-pdf/sample-files
 
 ## Copying
 

--- a/page.codeberg.censor.Censor.json
+++ b/page.codeberg.censor.Censor.json
@@ -10,33 +10,8 @@
     "--device=dri",
     "--socket=wayland"
   ],
-  "cleanup": [
-    "/include",
-    "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "*.la",
-    "*.a"
-  ],
   "modules": [
     "python3-pymupdf.json",
-    {
-      "name": "licenses-agpl",
-      "buildsystem": "simple",
-      "build-commands": [
-        "install -Dm644 agpl-3.0.txt /app/share/licenses/page.codeberg.censor.Censor/AGPL-3.0-only.txt"
-      ],
-      "sources": [
-        {
-          "type": "file",
-          "url": "https://www.gnu.org/licenses/agpl-3.0.txt",
-          "sha256": "0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0"
-        }
-      ]
-    },
     {
       "name": "censor",
       "builddir": true,
@@ -45,8 +20,19 @@
         {
           "type": "git",
           "url": "https://codeberg.org/censor/Censor.git",
-          "tag": "v0.4.0",
-          "commit": "45748a39969acac473cadd8f0ab33b4a286dacfa"
+          "branch": "main"
+        }
+      ]
+    },
+    {
+      "name": "compileall",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python -m compileall -q --invalidation-mode=unchecked-hash /app/share/censor /app/lib/python*"
+      ],
+      "sources": [
+        {
+          "commit": "c2b3f7ff8441daab9b283871d69ac507dbdc267c"
         }
       ]
     }

--- a/page.codeberg.censor.Censor.json
+++ b/page.codeberg.censor.Censor.json
@@ -20,7 +20,8 @@
         {
           "type": "git",
           "url": "https://codeberg.org/censor/Censor.git",
-          "branch": "main"
+          "tag": "v0.5.0",
+          "commit": "75d19a043237bef9fadf697441e0510fb5f1fedd"
         }
       ]
     },
@@ -29,12 +30,6 @@
       "buildsystem": "simple",
       "build-commands": [
         "python -m compileall -q --invalidation-mode=unchecked-hash /app/share/censor /app/lib/python*"
-      ],
-      "sources": [
-        {
-          "tag": "v0.5.0",
-          "commit": "75d19a043237bef9fadf697441e0510fb5f1fedd"
-        }
       ]
     }
   ]

--- a/page.codeberg.censor.Censor.json
+++ b/page.codeberg.censor.Censor.json
@@ -20,7 +20,7 @@
         {
           "type": "git",
           "url": "https://codeberg.org/censor/Censor.git",
-          "branch": "main"
+          "commit": "c2b3f7ff8441daab9b283871d69ac507dbdc267c"
         }
       ]
     },
@@ -29,11 +29,6 @@
       "buildsystem": "simple",
       "build-commands": [
         "python -m compileall -q --invalidation-mode=unchecked-hash /app/share/censor /app/lib/python*"
-      ],
-      "sources": [
-        {
-          "commit": "c2b3f7ff8441daab9b283871d69ac507dbdc267c"
-        }
       ]
     }
   ]

--- a/page.codeberg.censor.Censor.json
+++ b/page.codeberg.censor.Censor.json
@@ -20,7 +20,7 @@
         {
           "type": "git",
           "url": "https://codeberg.org/censor/Censor.git",
-          "commit": "c2b3f7ff8441daab9b283871d69ac507dbdc267c"
+          "branch": "main"
         }
       ]
     },
@@ -29,6 +29,12 @@
       "buildsystem": "simple",
       "build-commands": [
         "python -m compileall -q --invalidation-mode=unchecked-hash /app/share/censor /app/lib/python*"
+      ],
+      "sources": [
+        {
+          "tag": "v0.5.0",
+          "commit": "75d19a043237bef9fadf697441e0510fb5f1fedd"
+        }
       ]
     }
   ]

--- a/python3-pymupdf.json
+++ b/python3-pymupdf.json
@@ -21,5 +21,8 @@
         "x86_64"
       ]
     }
+  ],
+  "cleanup": [
+    "/lib/python*/site-packages/pymupdf/mupdf-devel"
   ]
 }


### PR DESCRIPTION
- the license file went into the data folder of Censor
- all is compiled at the end
- and some remains from PyMuPDF are cleaned up